### PR TITLE
docs: prioritize gh skill install over npx in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ An AI agent skill that uploads local images to a GitHub PR and embeds them in th
 ## Installation
 
 ```bash
+gh skill install tonkotsuboy/github-upload-image-to-pr github-upload-image-to-pr
+```
+
+or
+
+```bash
 npx skills add tonkotsuboy/github-upload-image-to-pr
 ```
 
@@ -58,6 +64,12 @@ Copyright 2026 tonkotsuboy
 ローカルの画像を GitHub PR に自動でアップロードし、PR の説明欄やコメントに埋め込む AI エージェント向けスキルです。
 
 ## インストール
+
+```bash
+gh skill install tonkotsuboy/github-upload-image-to-pr github-upload-image-to-pr
+```
+
+または
 
 ```bash
 npx skills add tonkotsuboy/github-upload-image-to-pr

--- a/skills/github-upload-image-to-pr/SKILL.md
+++ b/skills/github-upload-image-to-pr/SKILL.md
@@ -10,6 +10,7 @@ description: >-
   "show the image in the PR" should trigger this skill.
   Supports Playwright MCP / Chrome DevTools MCP / agent-browser as browser automation backends.
 allowed-tools: Bash(agent-browser:*), Bash(gh:*), Bash(npx:*), Bash(cp:*), ToolSearch, Read, Glob, Write
+license: MIT
 ---
 
 # Upload Image to PR


### PR DESCRIPTION
## Summary
- Present `gh skill install` as the primary installation method in both the English and Japanese README sections, with `npx skills add` listed as an alternative via "or" / 「または」.
- Add `license: MIT` to `skills/github-upload-image-to-pr/SKILL.md` frontmatter so the skill metadata reflects the repository license.

## Test plan
- [x] Render README.md locally and confirm both code blocks display correctly under "Installation" and 「インストール」
- [x] Verify SKILL.md frontmatter is still valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)