### PR TITLE
docs: mention gh --attach as the preferred alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # GitHub Upload Image to PR
 
+> [!IMPORTANT]
+> **On GitHub CLI v2.99.0+, use `gh`'s native `--attach` flag instead of this skill.** `gh pr create --attach ./screenshot.png` (or `gh pr edit --attach ./video.mp4`) uploads and embeds the file directly — no browser automation, no MCP server, no flakiness. See the [v2.99.0 release notes](https://github.com/cli/cli/releases/tag/v2.99.0). This skill is kept as a fallback for older `gh` versions.
+
 An AI agent skill that uploads local images to a GitHub PR and embeds them in the description or comments — automatically, just by asking.
 
 [日本語版はこちら](./README.ja.md)


### PR DESCRIPTION
## 内容

gh CLI v2.99.0 で `--attach` フラグがネイティブ実装されたため、README 冒頭に GitHub Alert (`[!IMPORTANT]`) で告知を追加しました。新しい `gh` を使っている場合はこのスキルより `--attach` を優先するよう案内しています。

- gh v2.99.0+ ではブラウザ自動化なしで画像・動画をアップロードできる
- 古い `gh` バージョンのフォールバックとしてこのスキル自体は残す

https://claude.ai/code/session_01CS37EjJryTMrgrg145rdCY