### PR TITLE
Prefer gh --attach over browser automation

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,5 +1,8 @@
 # GitHub Upload Image to PR
 
+> [!IMPORTANT]
+> **このスキルは GitHub CLI ネイティブの `--attach`（`gh` 2.99.0 以降）を優先して使います。** `gh` が新しければ `gh pr edit --attach ./screenshot.png`（または `gh pr comment --attach`）の1コマンドで完了し、ブラウザ自動化も MCP サーバーも不要です。`gh` が古い場合はアップグレードを促したうえで、従来のブラウザ経路にフォールバックして作業を完遂します。詳細は [v2.99.0 のリリースノート](https://github.com/cli/cli/releases/tag/v2.99.0) と [GitHub のドキュメント](https://docs.github.com/en/github-cli/github-cli/attaching-files-with-github-cli) を参照してください。
+
 ローカルの画像を GitHub PR に自動でアップロードし、PR の説明欄やコメントに埋め込む AI エージェント向けスキルです。
 
 [English version](./README.md)
@@ -28,13 +31,24 @@ npx skills add tonkotsuboy/github-upload-image-to-pr
 
 ## 仕組み
 
-### なぜ GitHub API を使わないのか
+`gh` のバージョンによって、2つの経路のどちらかを選びます。
 
-GitHub の公式 REST API には、PR の説明文やコメントに埋め込む画像をアップロードするエンドポイントが **存在しません**。GitHub API でできるのは、マークダウンテキストとして PR の内容を作成・編集することだけで、画像などのバイナリファイルをアップロードする手段は公式には提供されていません。
+### 経路A — `gh --attach`（推奨・`gh` 2.99.0 以降）
 
-そのため、このスキルでは**ブラウザ自動化**を使って、人間が GitHub の Web UI で行うのと同じ手順で画像をアップロードします。
+GitHub CLI 2.99.0 で `gh pr create` / `pr edit` / `pr comment`（および対応する `gh issue` 系コマンド）に、繰り返し指定できる `--attach` フラグが追加されました。アップロードは1コマンドで済みます。
 
-### 処理の流れ
+```bash
+gh pr edit 23 --attach './screenshot.png#ログインエラーの状態'
+gh pr comment 23 --attach ./before.png --attach ./after.png
+```
+
+`--body` を付けなければ既存の説明文はそのまま保たれ、添付が末尾に追記されます。本文に `![before](./before.png)` のようにローカルパスの参照があれば、その参照が**その場でアップロード後の URL に書き換えられる**ため、Before/After のテーブルのようなレイアウトも1コマンドで作れます。
+
+利用にはリポジトリへの push 権限が必要で、対応しているのは GitHub.com と GitHub Enterprise Cloud です（Enterprise Server は非対応）。
+
+### 経路B — ブラウザアップロード（フォールバック）
+
+GitHub の公式 REST API には、埋め込み用の画像をアップロードするエンドポイントが **存在しません**。そのため `--attach` が登場する前は、人間が Web UI で行うのと同じ手順をブラウザ自動化で再現するしかありませんでした。
 
 1. Chrome DevTools MCP または Playwright MCP でブラウザを操作し、**PR ページを開く**
 2. PR の会話欄の下部にある**コメントテキストエリアを見つける**
@@ -43,15 +57,15 @@ GitHub の公式 REST API には、PR の説明文やコメントに埋め込む
 5. テキストエリアを**クリアする**（コメントを投稿しなくても画像 URL は有効なまま残る）
 6. `gh pr edit` で **PR の説明文を更新**し、画像をマークダウンとして埋め込む
 
-このアプローチが成立するのは、GitHub の画像ホスティングがコメントの投稿とは独立しているためです。ファイルをアップロードした時点で画像は永続化され、コメントを送信しなくても URL はずっと有効です。
+このアプローチが成立するのは、GitHub の画像ホスティングがコメントの投稿とは独立しているためです。ファイルをアップロードした時点で画像は永続化され、コメントを送信しなくても URL はずっと有効です。スキルがこの経路を使うのは、`gh` が 2.99.0 より古い場合、ホストが Enterprise Server の場合、push 権限がない場合です。
 
 ## 必要なもの
 
 - スキルに対応した AI エージェント（例：[Claude Code](https://claude.ai/claude-code)）
-- 以下のいずれかのブラウザ自動化ツール：
+- [GitHub CLI (`gh`)](https://cli.github.com/) — **経路A には 2.99.0 以降が必要**。どちらの経路でも必須
+- 経路B（`gh` が古い場合）のみ、以下のいずれかのブラウザ自動化ツール：
   - **Chrome DevTools MCP**（推奨 — 既存のブラウザに接続し、ログイン状態を維持）
   - **Playwright MCP**（既存のブラウザインスタンスに接続）
-- [GitHub CLI (`gh`)](https://cli.github.com/) — API 経由で PR 説明文を更新するために使用
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # GitHub Upload Image to PR
 
 > [!IMPORTANT]
-> **On GitHub CLI v2.99.0+, use `gh`'s native `--attach` flag instead of this skill.** `gh pr create --attach ./screenshot.png` (or `gh pr edit --attach ./video.mp4`) uploads and embeds the file directly — no browser automation, no MCP server, no flakiness. See the [v2.99.0 release notes](https://github.com/cli/cli/releases/tag/v2.99.0). This skill is kept as a fallback for older `gh` versions.
+> **This skill now prefers GitHub CLI's native `--attach` flag (`gh` 2.99.0+).** When your `gh` is new enough, it runs `gh pr edit --attach ./screenshot.png` (or `gh pr comment --attach`) and is done — no browser automation, no MCP server, no flakiness. On older `gh` it prompts you to upgrade and falls back to the browser route so the work still gets done. See the [v2.99.0 release notes](https://github.com/cli/cli/releases/tag/v2.99.0) and [GitHub's docs](https://docs.github.com/en/github-cli/github-cli/attaching-files-with-github-cli).
 
 An AI agent skill that uploads local images to a GitHub PR and embeds them in the description or comments — automatically, just by asking.
 
@@ -31,13 +31,24 @@ Trigger the skill with phrases like:
 
 ## How It Works
 
-### Why not just use the GitHub API?
+The skill picks one of two paths based on your `gh` version.
 
-GitHub does **not** provide a public REST API endpoint for uploading image attachments to embed in PR descriptions or comments. The official GitHub API allows creating/editing PR content as markdown text, but has no endpoint for uploading binary files like images.
+### Path A — `gh --attach` (preferred, `gh` 2.99.0+)
 
-As a workaround, this skill uses **browser automation** to upload images the same way a human would through the GitHub web UI.
+GitHub CLI 2.99.0 added a repeatable `--attach` flag to `gh pr create` / `pr edit` / `pr comment` (and the matching `gh issue` commands), so uploading is a single command:
 
-### The mechanism
+```bash
+gh pr edit 23 --attach './screenshot.png#Login error state'
+gh pr comment 23 --attach ./before.png --attach ./after.png
+```
+
+Without `--body`, the existing description is kept and the attachment appended. If the body references a local path such as `![before](./before.png)`, that reference is rewritten in place — which is how you get Before/After tables and other layouts from one command.
+
+Requires push access to the repository, and works on GitHub.com and GitHub Enterprise Cloud (not Enterprise Server).
+
+### Path B — browser upload (fallback)
+
+GitHub does **not** provide a public REST API endpoint for uploading image attachments, so before `--attach` existed the only route was to drive a browser the way a human would:
 
 1. **Open the PR page** in a browser via Chrome DevTools MCP or Playwright MCP
 2. **Locate the comment textarea** at the bottom of the PR conversation
@@ -46,15 +57,15 @@ As a workaround, this skill uses **browser automation** to upload images the sam
 5. **Clear the textarea** (the image URL remains valid even without posting the comment)
 6. **Update the PR description** via `gh pr edit`, embedding the image as markdown
 
-This approach works because GitHub's image hosting is separate from comment submission — images are persisted the moment they're uploaded, regardless of whether the comment is ever posted.
+This works because GitHub's image hosting is separate from comment submission — images persist the moment they're uploaded, whether or not the comment is ever posted. The skill uses this path when `gh` is older than 2.99.0, when the host is Enterprise Server, or when you lack push access.
 
 ## Requirements
 
 - An AI agent that supports skills (e.g., [Claude Code](https://claude.ai/claude-code))
-- One of the following browser automation tools:
+- [GitHub CLI (`gh`)](https://cli.github.com/) — **2.99.0 or newer for Path A**; required in both paths
+- Only for Path B (older `gh`), one of the following browser automation tools:
   - **Chrome DevTools MCP** (recommended — connects to your existing browser, login state preserved)
   - **Playwright MCP** (connects to an existing browser instance)
-- [GitHub CLI (`gh`)](https://cli.github.com/) — for updating the PR description via API
 
 ## License
 

--- a/skills/github-upload-image-to-pr/SKILL.md
+++ b/skills/github-upload-image-to-pr/SKILL.md
@@ -1,28 +1,137 @@
 ---
 name: github-upload-image-to-pr
 description: >-
-  Upload local images to a GitHub PR and embed them in the description or comments.
+  Upload local images or videos to a GitHub PR and embed them in the description or comments.
   Use when asked to "attach screenshots to PR", "add images to PR", "upload test results to PR",
   "embed screenshots in PR description", "add before/after images to PR", "attach UI screenshots",
   "show test results in PR", "add visual evidence to PR", or any request involving images and PRs.
   Always use this skill when the user wants to visually document changes in a pull request,
   even if they don't use the word "upload" — phrases like "put the screenshot in the PR" or
   "show the image in the PR" should trigger this skill.
-  Prefers Chrome DevTools MCP (most stable) as the browser automation backend, falling back to
-  Playwright MCP or agent-browser only when Chrome DevTools MCP is unavailable.
-allowed-tools: Bash(agent-browser:*), Bash(gh:*), Bash(npx:*), Bash(cp:*), Bash(rm:*), Bash(sleep:*), mcp__chrome-devtools, mcp__playwright, ToolSearch, Read, Glob, Write
+  Prefers GitHub CLI's native `--attach` flag (gh 2.99.0+), which needs no browser at all, and
+  falls back to browser automation (Chrome DevTools MCP, then Playwright MCP, then agent-browser)
+  only when `gh --attach` is unavailable.
+allowed-tools: Bash(agent-browser:*), Bash(gh:*), Bash(brew:*), Bash(npx:*), Bash(cp:*), Bash(rm:*), Bash(sleep:*), mcp__chrome-devtools, mcp__playwright, ToolSearch, Read, Glob, Write
 license: MIT
 ---
 
 # Upload Image to PR
 
-Upload local images to a GitHub PR and embed them in the description or comments using browser automation tools.
+There are two ways to get a local image into a PR, and they differ enormously in cost and reliability:
 
-## How It Works
+- **Path A — `gh --attach`** (GitHub CLI 2.99.0+, released 2026-09): one shell command. No browser, no MCP server, no snapshots, no polling. Use this whenever it's available.
+- **Path B — browser upload** (fallback): drive a real browser to GitHub's comment box, which is the only public way to reach GitHub's image host on older `gh`. Many steps, many failure modes, lots of tokens.
 
-Since the GitHub API does not support direct image uploads, this skill uses the **PR comment textarea as a staging area for GitHub's image hosting** — uploading files there to obtain persistent `user-attachments/assets/` URLs, then updating the PR description or posting a comment via the `gh` CLI.
+Path B exists because GitHub's REST API still has no image-upload endpoint. Path A works because `gh` itself now talks to the internal upload endpoint for you — so treat Path B as legacy, not as an equal alternative.
 
-## Step 0: Resolve PR context
+## Step 1: Pick the path
+
+```bash
+GH_VER=$(gh --version 2>/dev/null | head -1 | awk '{print $3}')
+echo "gh: ${GH_VER:-not installed}"
+# Path A requires >= 2.99.0
+[ -n "$GH_VER" ] && [ "$(printf '%s\n2.99.0\n' "$GH_VER" | sort -V | head -1)" = "2.99.0" ] \
+  && echo "=> Path A (gh --attach)" || echo "=> Path B (browser fallback)"
+```
+
+Use **Path B** when any of these hold:
+
+| Condition | Why Path A can't work |
+|-----------|-----------------------|
+| `gh` older than 2.99.0, or not installed | The `--attach` flag doesn't exist yet |
+| Host is GitHub Enterprise **Server** | Attachments ship on GitHub.com and Enterprise **Cloud** only |
+| No push access to the repo (e.g. someone else's fork) | `--attach` uploads require push access |
+| `gh --attach` fails for an unclear reason | Don't sink time into it — note the error and fall back |
+
+`gh` is needed in **both** paths (Path B still embeds via `gh pr edit`), so if it isn't installed at all, ask the user to install it first: `brew install gh` (macOS) or see <https://cli.github.com/>.
+
+### If you land on Path B because `gh` is old, say so loudly
+
+The user is about to pay for a slow, flaky browser session that a one-liner would have handled. That's worth interrupting for — but not worth blocking on, so surface the notice, then get on with Path B and deliver the images. Lead your reply with something like this (match the user's language):
+
+> ⚠️ **`gh` を更新すると、この作業はコマンド1発になります**
+> 現在: `gh 2.86.0` / 必要: **2.99.0 以上**
+> 更新後は `gh pr comment 123 --attach ./shot.png` だけで完了します（ブラウザ操作なし・高速・安定）。
+> 更新コマンド: `brew upgrade gh`
+> 今回はブラウザ自動化で続行します。
+
+If the user asks you to upgrade, run the upgrade, re-check the version, and switch to Path A for the current request too.
+
+---
+
+## Path A — `gh --attach` (preferred)
+
+`--attach` takes `<file>` or `<file>#<alt text>`, is repeatable (up to 50 files per command, and the same file can't be attached twice), and is available on `gh pr create` / `pr edit` / `pr comment` and the three matching `gh issue` commands.
+
+### Append to the PR description
+
+```bash
+gh pr edit {PR_NUMBER} --attach './screenshot.png#Login error state'
+```
+
+Leaving `--body` off keeps the existing description and appends the attachment — no need to read the body and stitch it back together.
+
+### Attach while creating the PR
+
+If the PR doesn't exist yet, don't create it and then edit it — attach in the same call:
+
+```bash
+gh pr create --title '...' --body '...' --attach './screenshot.png#Login error state'
+```
+
+### Control where the images land
+
+If the body references a local path, `gh` rewrites **that reference in place** instead of appending, so you can lay images out however you like (alt text then comes from the markdown, not from the flag):
+
+```bash
+gh pr edit {PR_NUMBER} --body "$(gh pr view {PR_NUMBER} --json body -q .body)
+
+## Screenshots
+
+| Before | After |
+| --- | --- |
+| ![before](./before.png) | ![after](./after.png) |" \
+  --attach ./before.png --attach ./after.png
+```
+
+Two things to keep straight here: `--body` **replaces** the description, which is why the existing body is read back in first; and the path string in the body must match the one passed to `--attach` for the rewrite to fire.
+
+### Post as a comment instead
+
+```bash
+gh pr comment {PR_NUMBER} --attach './result.png#Test run summary'
+```
+
+Same rewrite rule applies with `--body`, so a comment can carry a layout too.
+
+### Videos
+
+`mp4` / `mov` attach the same way and render as a player. Video has no alt text, so don't add a `#...` suffix for one.
+
+### Verify
+
+No browser needed — read the body back and count the attachments:
+
+```bash
+gh pr view {PR_NUMBER} --json body -q .body | grep -c 'user-attachments/assets'
+```
+
+### Path A gotchas
+
+- **Attaching only appends; it never replaces.** Re-running the same command duplicates the images. To swap an image out, rewrite the body without the stale URL (`gh pr edit {PR} --body "$(...)"`) in the same command that attaches the new one.
+- **A `#` in the filename breaks the `<file>#<alt>` split.** Stage a copy with a plain ASCII name first (`cp './weird #name.png' ./shot.png`) and `rm` it afterwards. The same trick handles the Unicode narrow spaces CleanShot X puts in filenames.
+- **Partial failure still succeeds partially.** If some files upload and others don't, the PR is updated with the ones that worked, the PR URL is still printed, and the exit status is non-zero. Read the output and report which files failed rather than assuming all-or-nothing.
+- Only images and media files are accepted — not arbitrary attachments like `.zip` or `.log`.
+
+---
+
+## Path B — Browser upload (fallback for `gh` < 2.99.0)
+
+Everything below is the legacy route. Reach for it only after Step 1 sent you here.
+
+Since older `gh` can't reach GitHub's image host, this path uses the **PR comment textarea as a staging area for that host** — uploading files there to obtain persistent `user-attachments/assets/` URLs, then updating the PR description or posting a comment via the `gh` CLI.
+
+### Step B0: Resolve PR context and stage the files
 
 If the user didn't specify a PR number or URL, auto-detect it:
 
@@ -45,9 +154,9 @@ Why stage inside the repo and not `/tmp/`? MCP browser tools (Playwright / Chrom
 
 Staging also sidesteps paths with special characters (e.g. the Unicode narrow spaces CleanShot X puts in filenames), which otherwise break shell globbing and tool arguments. Remember to `rm` the staged file once you're done so it isn't accidentally committed.
 
-## Tool Detection and Selection
+### Tool Detection and Selection
 
-### Priority Order
+#### Priority Order
 
 1. **Chrome DevTools MCP** (MCP connection, `mcp__chrome-devtools__*`) — **preferred**: connects to existing browser, login state preserved, most stable of the three backends
 2. **Playwright MCP** (MCP connection, `mcp__playwright__*`) — use only if Chrome DevTools MCP is unavailable; connects to existing browser, login state preserved
@@ -55,7 +164,7 @@ Staging also sidesteps paths with special characters (e.g. the Unicode narrow sp
 
 MCP-based tools connect to an already-running browser instance, so **GitHub login state is automatically preserved**. agent-browser can persist login state using `--profile ~/.agent-browser-github`.
 
-### Detection
+#### Detection
 
 ```
 # 1. Search specifically for Chrome DevTools MCP first (preferred, most stable)
@@ -68,7 +177,7 @@ ToolSearch: "browser navigate upload"
 Bash: agent-browser --version
 ```
 
-## Tool Compatibility Matrix
+### Tool Compatibility Matrix
 
 | Operation | Chrome DevTools MCP (preferred) | Playwright MCP (fallback) | agent-browser (CLI/Bash) |
 |-----------|----------------------------------|----------------------------|--------------------------|
@@ -80,9 +189,7 @@ Bash: agent-browser --version
 | **JS Eval** | `evaluate_script` (function) | `browser_evaluate` (function) | `agent-browser eval '{js}'` |
 | **Login State** | Preserved | Preserved | Preserved with `--profile` |
 
-## Steps
-
-### Step 1: Navigate to PR page and check login state
+### Step B1: Navigate to PR page and check login state
 
 Navigate to the PR page and immediately take a snapshot to verify login state.
 
@@ -104,7 +211,7 @@ agent-browser --headed --profile ~/.agent-browser-github open "https://github.co
 2. Ask the user to log in manually in the headed browser window.
 3. Wait for user confirmation, then navigate back to the PR page.
 
-### Step 2: Locate the upload target
+### Step B2: Locate the upload target
 
 Scroll to the comment form at the bottom of the PR and take a snapshot.
 
@@ -131,11 +238,11 @@ button "Attach files"
 button "Paste, drop, or click to add files"   ← pass this uid/ref to the upload tool
 ```
 
-The comment box itself is a `<file-attachment>` web component wrapping a `<textarea id="new_comment_field">` — that textarea is where the resulting image reference lands (Step 4). GitHub's UI shifts over time, so if `new_comment_field` isn't there, fall back to `textarea[name="comment[body]"]` or `textarea[id*="comment"]`; the PR-description editor instead uses `textarea[name="pull_request[body]"]` / `textarea[id$="-body"]`.
+The comment box itself is a `<file-attachment>` web component wrapping a `<textarea id="new_comment_field">` — that textarea is where the resulting image reference lands (Step B4). GitHub's UI shifts over time, so if `new_comment_field` isn't there, fall back to `textarea[name="comment[body]"]` or `textarea[id*="comment"]`; the PR-description editor instead uses `textarea[name="pull_request[body]"]` / `textarea[id$="-body"]`.
 
-### Step 3: Upload the image(s)
+### Step B3: Upload the image(s)
 
-Upload each file with the detected tool, passing the **dropzone / attach-button uid** from Step 2 (never the hidden input):
+Upload each file with the detected tool, passing the **dropzone / attach-button uid** from Step B2 (never the hidden input):
 
 ```javascript
 // Chrome DevTools MCP (preferred): upload_file({ uid: <dropzone uid>, filePath: <path inside the workspace root> })
@@ -143,9 +250,9 @@ Upload each file with the detected tool, passing the **dropzone / attach-button 
 // agent-browser (last resort):     agent-browser upload {ref} {absolute_path}    (any path, /tmp/ ok)
 ```
 
-Use the in-repo staged path from Step 0 for the MCP backends (see the workspace-root note there). Wait **2–3 seconds between uploads**. For multiple images, upload them all into the same comment box before extracting URLs — more efficient than navigating between uploads.
+Use the in-repo staged path from Step B0 for the MCP backends (see the workspace-root note there). Wait **2–3 seconds between uploads**. For multiple images, upload them all into the same comment box before extracting URLs — more efficient than navigating between uploads.
 
-### Step 4: Retrieve the uploaded image URL(s)
+### Step B4: Retrieve the uploaded image URL(s)
 
 While uploading, GitHub shows a placeholder (`![Uploading file.png…]()`) in the textarea, then swaps it for the final reference once the file lands. So **poll the textarea until a `user-attachments/assets/` URL appears** instead of trusting a fixed sleep — it usually takes 1–5 seconds.
 
@@ -175,7 +282,7 @@ agent-browser eval 'const ta=document.getElementById("new_comment_field")||docum
 
 Keep the whole `<img …>` tag if you want to preserve GitHub's auto-detected `width`/`height`; otherwise take just the URL and wrap it yourself (`![alt](url)` or your own `<img>`).
 
-### Step 5: Clear the textarea (do not submit the comment)
+### Step B5: Clear the textarea (do not submit the comment)
 
 Dispatch an `input` event after clearing so GitHub's comment-draft autosave also clears — otherwise the staged content can reappear on the next page load.
 
@@ -196,7 +303,7 @@ Dispatch an `input` event after clearing so GitHub's comment-draft autosave also
 agent-browser eval 'const ta=document.getElementById("new_comment_field")||document.querySelector("textarea[id*=comment]"); if(ta){ta.value="";ta.dispatchEvent(new Event("input",{bubbles:true}))} "cleared"'
 ```
 
-### Step 6: Embed images in the PR
+### Step B6: Embed images in the PR
 
 Embed using either the full `<img …>` tag GitHub gave you (keeps the auto-detected size) or plain markdown `![alt](url)`.
 
@@ -216,7 +323,7 @@ gh pr comment {PR_NUMBER} --body '## Screenshots
 
 Use Option A by default unless the user explicitly asks for a comment, or if the PR description is already long and a comment would be cleaner.
 
-### Step 7: Verify the result
+### Step B7: Verify the result
 
 Reload the page and take a screenshot to confirm the images are displayed correctly.
 
@@ -231,30 +338,44 @@ Also assert programmatically that the images actually loaded. **Match both URL f
 }
 ```
 
-`loaded: true` on every entry means the embed worked. An empty array means the `<img>` tags never made it into the body — re-check Step 6.
+`loaded: true` on every entry means the embed worked. An empty array means the `<img>` tags never made it into the body — re-check Step B6.
 
 ## Tips
 
-- **Image sizing**: Control display size via HTML `<img>` tags: `<img width="800" alt="description" src="..." />`
-- **Multiple images**: Upload all images in one session to the same textarea; extract all URLs before clearing
-- **Prefer Chrome DevTools MCP**: It's the most stable backend — always try it first via `ToolSearch`. Fall back to Playwright MCP only if Chrome DevTools MCP tools aren't found, and to agent-browser only if no MCP tools are available at all
+- **Try Path A first, every time**: one `gh pr edit --attach` / `gh pr comment --attach` call replaces the entire browser session below. Only the conditions in Step 1 justify Path B
+- **Image sizing**: `--attach` lets GitHub pick the size; on Path B (or when you hand-write the markup) control it with `<img width="800" alt="description" src="..." />`
+- **Multiple images**: Path A repeats `--attach` in one command; Path B uploads all images into the same textarea, then extracts all URLs before clearing
+- **Prefer Chrome DevTools MCP within Path B**: It's the most stable backend — always try it first via `ToolSearch`. Fall back to Playwright MCP only if Chrome DevTools MCP tools aren't found, and to agent-browser only if no MCP tools are available at all
 - **agent-browser login persistence**: Use `--profile ~/.agent-browser-github` to persist GitHub login across sessions
 
 ## Troubleshooting
+
+### Path A (`gh --attach`)
+
+| Issue | Solution |
+|-------|----------|
+| `unknown flag: --attach` | `gh` is older than 2.99.0 — nudge the user to upgrade (Step 1) and continue on Path B |
+| Images duplicated after a re-run | `--attach` only appends. Rewrite the body without the stale URLs in the same `gh pr edit --body ... --attach ...` call |
+| Upload rejected / permission error | `--attach` needs push access, and works on GitHub.com and Enterprise **Cloud** only. Fall back to Path B |
+| Alt text swallowed the filename, or the file isn't found | A `#` in the path is parsed as the alt-text separator — stage a copy with a plain ASCII name |
+| Some files uploaded, command exited non-zero | Expected behavior for partial failure: the PR keeps the successful ones. Report which files failed and retry just those |
+| Body reference wasn't rewritten, image appended at the end instead | The path in the body must match the `--attach` path string exactly |
+
+### Path B (browser upload)
 
 | Issue | Solution |
 |-------|----------|
 | Not logged in (MCP tools) | SSO screen may appear — take snapshot, find "Continue" button, click it |
 | Not logged in (agent-browser) | Use `--headed` mode, navigate to login page, ask user to log in manually |
 | Browser window not visible | For agent-browser, ensure `--headed` flag is used |
-| File path with special characters (e.g., Unicode narrow spaces from CleanShot) | Stage a copy with a simple name inside the repo: `cp /path/'CleanShot ... .png' ./.upload-staging.png` (in-repo so MCP tools can read it — see Step 0) |
-| `Access denied: path ... not within any of the configured workspace roots` | MCP browser tools only read files inside their workspace root. Stage the image **inside the repo** (Step 0), not `/tmp/` |
-| Can't find a uid/ref for the file input | The `<input type="file">` is `display:none` and absent from the snapshot — target the visible *"Paste, drop, or click to add files"* dropzone or *"Attach files"* button instead (Step 2) |
-| PR page snapshot is huge / feels too expensive to take | Pass `filePath` to `take_snapshot` and `grep` the file for the dropzone uid (Step 2). Don't let snapshot size push you into inlining base64 into `evaluate_script` |
-| Verification finds 0 images even though they render | GitHub rewrites the asset URL to `private-user-images.githubusercontent.com` on render — match both that and `user-attachments`, then check `naturalWidth > 0` (Step 7) |
-| Textarea has the file but no `![](url)` markdown | GitHub inserts an `<img …>` HTML tag for images, not Markdown. Extract the `user-attachments/assets/` URL with the regex in Step 4, which matches both forms |
+| File path with special characters (e.g., Unicode narrow spaces from CleanShot) | Stage a copy with a simple name inside the repo: `cp /path/'CleanShot ... .png' ./.upload-staging.png` (in-repo so MCP tools can read it — see Step B0) |
+| `Access denied: path ... not within any of the configured workspace roots` | MCP browser tools only read files inside their workspace root. Stage the image **inside the repo** (Step B0), not `/tmp/` |
+| Can't find a uid/ref for the file input | The `<input type="file">` is `display:none` and absent from the snapshot — target the visible *"Paste, drop, or click to add files"* dropzone or *"Attach files"* button instead (Step B2) |
+| PR page snapshot is huge / feels too expensive to take | Pass `filePath` to `take_snapshot` and `grep` the file for the dropzone uid (Step B2). Don't let snapshot size push you into inlining base64 into `evaluate_script` |
+| Verification finds 0 images even though they render | GitHub rewrites the asset URL to `private-user-images.githubusercontent.com` on render — match both that and `user-attachments`, then check `naturalWidth > 0` (Step B7) |
+| Textarea has the file but no `![](url)` markdown | GitHub inserts an `<img …>` HTML tag for images, not Markdown. Extract the `user-attachments/assets/` URL with the regex in Step B4, which matches both forms |
 | Textarea doesn't contain URLs yet | GitHub shows an `![Uploading…]()` placeholder first — poll the textarea until a `user-attachments/assets/` URL appears (1–5s) instead of a fixed wait |
-| Textarea selector not found | GitHub UI changes occasionally — fall back through `new_comment_field` → `textarea[name="comment[body]"]` → `textarea[id*="comment"]` (Step 2) |
+| Textarea selector not found | GitHub UI changes occasionally — fall back through `new_comment_field` → `textarea[name="comment[body]"]` → `textarea[id*="comment"]` (Step B2) |
 | Chrome DevTools MCP disconnected | Reconnect via `/mcp` command |
 | agent-browser not found | `npm install -g agent-browser && agent-browser install` |
 | No browser tools found | Use `ToolSearch` to search for available browser tools |
@@ -262,9 +383,10 @@ Also assert programmatically that the images actually loaded. **Match both URL f
 
 ## Notes
 
+- `gh --attach` landed in GitHub CLI **2.99.0** (2026-09) on `gh pr create` / `pr edit` / `pr comment` and the matching `gh issue create` / `issue edit` / `issue comment`. Up to 50 files per command; the same file can't be attached twice
+- `gh pr edit --attach` without `--body` keeps the existing description and appends — the read-modify-write dance is only needed when you want to control placement
 - GitHub `user-attachments/assets/` URLs are **persistent** — images remain accessible even without submitting the comment. When rendered, GitHub rewrites them to `private-user-images.githubusercontent.com` CDN URLs; the `user-attachments/assets/...` form is the stable one to embed
-- On upload, GitHub injects an `<img width=… height=… alt=… src=… />` tag (alt is derived from the filename) — not `![](…)` markdown. Extract by the asset URL, not the wrapper
+- On Path B upload, GitHub injects an `<img width=… height=… alt=… src=… />` tag (alt is derived from the filename) — not `![](…)` markdown. Extract by the asset URL, not the wrapper
 - MCP browser tools can only read upload files inside their workspace root, so stage images in the repo, not `/tmp/`
 - Editing the description directly in the browser UI is fragile due to GitHub UI structure changes — updating via `gh pr edit` is strongly preferred
-- Multiple images can be uploaded in a single session before extracting URLs
 - MCP-based tools connect to existing browser instances, preserving cookies and login sessions


### PR DESCRIPTION
## Summary

GitHub CLI 2.99.0 added a repeatable `--attach` flag to `gh pr create` / `pr edit` / `pr comment` (and the matching `gh issue` commands), so uploading and embedding a local image or video is now a single command. This PR makes the skill reach for that first and demotes the browser-automation route to a fallback.

## Changes

### `skills/github-upload-image-to-pr/SKILL.md`

- **Step 1 now picks a path based on the `gh` version** (a `sort -V` comparison against 2.99.0)
- **New Path A — `gh --attach` (preferred)**
  - Append to the PR description (omitting `--body` keeps the existing body)
  - Lay images out on purpose by referencing the local path in the body, which `gh` rewrites in place — Before/After tables in one command
  - Attach while creating the PR, attach to a comment, videos, and verification that needs nothing but `gh pr view`
  - Gotchas: append-only with no replace, a `#` in the filename collides with the alt-text separator, and partial failure exits non-zero while keeping the files that succeeded
- **Path B — browser upload (fallback)** keeps the existing procedure verbatim, renumbered to Steps B0–B7
- The conditions that justify Path B are spelled out in a table: `gh` older than 2.99.0, GitHub Enterprise **Server**, or no push access
- When Path B is chosen only because `gh` is old, the skill surfaces a **prominent upgrade notice** and then carries on, so the user learns about the one-liner without the current request being blocked
- Troubleshooting is split into Path A and Path B tables

### `README.md` / `README.ja.md`

- Both rewritten around the two paths, with "Path A requires gh 2.99.0+" called out under Requirements
- The `--attach` notice that only existed in the English README is now in the Japanese one too, and the two files are back in sync

## References

- [gh v2.99.0 release notes](https://github.com/cli/cli/releases/tag/v2.99.0)
- [Attaching files with GitHub CLI](https://docs.github.com/en/github-cli/github-cli/attaching-files-with-github-cli)

## Verification

The version gate was checked against real values: `2.98.0` / `2.9.0` / not installed resolve to Path B, and `2.99.0` / `2.99.1` / `2.100.0` / `3.0.0` resolve to Path A. The supported commands and documented behavior of `--attach` were confirmed against the actual `--help` output of `gh 2.99.0` and the official docs.

https://claude.ai/code/session_01H2HfssFCgnybGt8vCYgJis

https://github.com/user-attachments/assets/c6121c38-7007-4e75-8493-8c1491cfa2b3